### PR TITLE
cache desired state to avoid extra dry-run

### DIFF
--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -305,8 +305,9 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 			extractor:         applyExtractor,
 			desiredStateCache: c.stateCacheManager.LoadOrNewForManaged(mg),
 		}
-		// for cache entry clean-up at delete
-		e.desiredStateCacheManager = c.stateCacheManager
+		e.desiredStateCacheCleanupFn = func() {
+			c.stateCacheManager.Remove(mg)
+		}
 	}
 
 	return e, nil
@@ -323,8 +324,9 @@ type external struct {
 
 	sanitizeSecrets bool
 
-	// for removing desired state cache for MR at deletion
-	desiredStateCacheManager ssa.StateCacheManager
+	// for cleaning-up the desired state cache of MR from
+	// state cache manager, when MR gets deleted
+	desiredStateCacheCleanupFn func()
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) { // nolint:gocyclo, mostly branches due to feature flags, hopefully will be refactored once they are promoted
@@ -442,8 +444,8 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 
 	// SSA is enabled
-	if c.desiredStateCacheManager != nil {
-		c.desiredStateCacheManager.Remove(mg)
+	if c.desiredStateCacheCleanupFn != nil {
+		c.desiredStateCacheCleanupFn()
 	}
 	return errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res)), errDeleteObject)
 }

--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -180,7 +180,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 		usage:           resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 		clientBuilder:   kubeclient.NewIdentityAwareBuilder(mgr.GetClient()),
 
-		stateCacheManager: ssa.NewDesiredStateCacheStore(ssa.WithCacheStoreLogger(l)),
+		stateCacheManager: ssa.NewDesiredStateCacheStore(),
 	}
 
 	if o.Features.Enabled(features.EnableAlphaServerSideApply) {

--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -180,7 +180,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 		usage:           resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 		clientBuilder:   kubeclient.NewIdentityAwareBuilder(mgr.GetClient()),
 
-		stateCacheManager: ssa.NewDesiredStateCacheStore(),
+		stateCacheManager: ssa.NewDesiredStateCacheManager(),
 	}
 
 	if o.Features.Enabled(features.EnableAlphaServerSideApply) {

--- a/internal/controller/object/syncer.go
+++ b/internal/controller/object/syncer.go
@@ -2,6 +2,8 @@ package object
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,6 +16,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha2"
+	"github.com/crossplane-contrib/provider-kubernetes/pkg/kube/client/ssa"
 )
 
 // PatchingResourceSyncer is a ResourceSyncer that syncs objects by patching
@@ -63,8 +66,9 @@ func (p *PatchingResourceSyncer) SyncResource(ctx context.Context, obj *v1alpha2
 // SSAResourceSyncer is a ResourceSyncer that syncs objects by using server-side
 // apply to apply the object's manifest to the Kubernetes API server.
 type SSAResourceSyncer struct {
-	client    client.Client
-	extractor applymetav1.UnstructuredExtractor
+	client            client.Client
+	extractor         applymetav1.UnstructuredExtractor
+	desiredStateCache ssa.StateCache
 }
 
 // GetObservedState returns the object's observed state by extracting the
@@ -77,6 +81,16 @@ func (s *SSAResourceSyncer) GetObservedState(_ context.Context, obj *v1alpha2.Ob
 // server-side apply on the object's manifest to see what the object would look
 // like if it were applied and extracting the managed fields from that.
 func (s *SSAResourceSyncer) GetDesiredState(ctx context.Context, obj *v1alpha2.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	cachedDesired, cachedHash := s.desiredStateCache.GetState()
+	// Note(erhancagirici): cache assumes the raw manifest is the sole factor
+	// affecting the desired state of the upstream k8s object.
+	// Any further development in the v1alpha2.Object semantics
+	// affecting the desired state, should include it in the hash.
+	manifestSum := sha256.Sum256(obj.Spec.ForProvider.Manifest.Raw)
+	manifestHash := hex.EncodeToString(manifestSum[:])
+	if cachedDesired != nil && cachedHash == manifestHash {
+		return cachedDesired.DeepCopy(), nil
+	}
 	// Note(turkenh): This dry run call is mostly a workaround for the
 	// following issue: https://github.com/kubernetes/kubernetes/issues/115563
 	// In an ideal world, we should be able to compare the extracted
@@ -93,6 +107,8 @@ func (s *SSAResourceSyncer) GetDesiredState(ctx context.Context, obj *v1alpha2.O
 		return nil, errors.Wrap(CleanErr(err), "cannot dry run SSA")
 	}
 	desired, err := s.extractor.Extract(desiredObj, ssaFieldOwner(obj.Name))
+	// in error case, is set to nil, effectively invalidating the entry
+	s.desiredStateCache.SetState(desired, manifestHash)
 	return desired, errors.Wrap(err, "cannot extract SSA")
 }
 

--- a/pkg/kube/client/ssa/state_cache.go
+++ b/pkg/kube/client/ssa/state_cache.go
@@ -59,27 +59,27 @@ func (dc *DesiredStateCache) SetStateFor(obj *objectv1alpha2.Object, state *unst
 	dc.hash = manifestHash
 }
 
-// DesiredStateCacheStore stores the DesiredStateCache instances associated with the
+// DesiredStateCacheManager stores the DesiredStateCache instances associated with the
 // managed resource instance.
-type DesiredStateCacheStore struct {
+type DesiredStateCacheManager struct {
 	mu    sync.RWMutex
 	store map[types.UID]*DesiredStateCache
 }
 
-// NewDesiredStateCacheStore returns a new DesiredStateCacheStore instance
-func NewDesiredStateCacheStore() *DesiredStateCacheStore {
-	return &DesiredStateCacheStore{
+// NewDesiredStateCacheManager returns a new DesiredStateCacheManager instance
+func NewDesiredStateCacheManager() *DesiredStateCacheManager {
+	return &DesiredStateCacheManager{
 		store: map[types.UID]*DesiredStateCache{},
 	}
 }
 
 // LoadOrNewForManaged returns the associated *DesiredStateCache stored in this
-// DesiredStateCacheStore for the given managed resource.
+// DesiredStateCacheManager for the given managed resource.
 // If there is no DesiredStateCache stored previously, a new DesiredStateCache is created and
 // stored for the specified managed resource. Subsequent calls with the same managed
 // resource will return the previously instantiated and stored DesiredStateCache
 // for that managed resource
-func (dcs *DesiredStateCacheStore) LoadOrNewForManaged(mg xpresource.Managed) StateCache {
+func (dcs *DesiredStateCacheManager) LoadOrNewForManaged(mg xpresource.Managed) StateCache {
 	dcs.mu.RLock()
 	stateCache, ok := dcs.store[mg.GetUID()]
 	dcs.mu.RUnlock()
@@ -99,8 +99,8 @@ func (dcs *DesiredStateCacheStore) LoadOrNewForManaged(mg xpresource.Managed) St
 }
 
 // Remove will remove the stored DesiredStateCache of the given managed
-// resource from this DesiredStateCacheStore.
-func (dcs *DesiredStateCacheStore) Remove(mg xpresource.Managed) {
+// resource from this DesiredStateCacheManager.
+func (dcs *DesiredStateCacheManager) Remove(mg xpresource.Managed) {
 	dcs.mu.Lock()
 	defer dcs.mu.Unlock()
 	delete(dcs.store, mg.GetUID())

--- a/pkg/kube/client/ssa/state_cache.go
+++ b/pkg/kube/client/ssa/state_cache.go
@@ -1,0 +1,142 @@
+package ssa
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+)
+
+// StateCacheManager lets you manage StateCache entries for XP managed
+// resources
+type StateCacheManager interface {
+	LoadOrNewForManaged(mg xpresource.Managed) StateCache
+	Remove(mg xpresource.Managed)
+}
+
+// StateCache is the interface for the caching a k8s
+// *unstructed.Unstructured object
+type StateCache interface {
+	SetState(state *unstructured.Unstructured, hash string)
+	GetState() (*unstructured.Unstructured, string)
+	HasState() bool
+}
+
+// DesiredStateCache is a concurrency-safe implementation of StateCache
+// that holds a cached k8s object state with a hash key of the associated
+// manifest.
+// Hash key can be used to determine the
+type DesiredStateCache struct {
+	logger    logging.Logger
+	mu        *sync.Mutex
+	extracted *unstructured.Unstructured
+	hash      string
+}
+
+// DesiredStateCacheOption lets you configure the DesiredStateCache parameters
+type DesiredStateCacheOption func(dsc *DesiredStateCache)
+
+// WithLogger sets the logger of DesiredStateCache.
+func WithLogger(l logging.Logger) DesiredStateCacheOption {
+	return func(w *DesiredStateCache) {
+		w.logger = l
+	}
+}
+
+// NewDesiredStateCache initializes a DesiredStateCache with given options
+func NewDesiredStateCache(opts ...DesiredStateCacheOption) *DesiredStateCache {
+	w := &DesiredStateCache{
+		logger: logging.NewNopLogger(),
+		mu:     &sync.Mutex{},
+	}
+	for _, f := range opts {
+		f(w)
+	}
+	return w
+}
+
+// GetState returns the stored desired state and the hash of associated
+// manifest
+func (dc *DesiredStateCache) GetState() (*unstructured.Unstructured, string) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.extracted, dc.hash
+}
+
+// HasState returns whether the DesiredStateCache has a stored state
+func (dc *DesiredStateCache) HasState() bool {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.extracted != nil
+}
+
+// SetState stores the given desired k8s object state into
+// the DesiredStateCache
+func (dc *DesiredStateCache) SetState(state *unstructured.Unstructured, hash string) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	dc.extracted = state
+	dc.hash = hash
+}
+
+// DesiredStateCacheStore stores the DesiredStateCache instances associated with the
+// managed resource instance.
+type DesiredStateCacheStore struct {
+	store  map[types.UID]*DesiredStateCache
+	logger logging.Logger
+	mu     *sync.Mutex
+}
+
+// DesiredStateCacheStoreOption lets you configure the DesiredStateCacheStore parameters
+type DesiredStateCacheStoreOption func(dcs *DesiredStateCacheStore)
+
+// WithCacheStoreLogger sets the logger of DesiredStateCacheStore.
+func WithCacheStoreLogger(l logging.Logger) DesiredStateCacheStoreOption {
+	return func(d *DesiredStateCacheStore) {
+		d.logger = l
+	}
+}
+
+// NewDesiredStateCacheStore returns a new DesiredStateCacheStore instance
+func NewDesiredStateCacheStore(opts ...DesiredStateCacheStoreOption) *DesiredStateCacheStore {
+	dcs := &DesiredStateCacheStore{
+		store:  map[types.UID]*DesiredStateCache{},
+		logger: logging.NewNopLogger(),
+		mu:     &sync.Mutex{},
+	}
+
+	for _, f := range opts {
+		f(dcs)
+	}
+
+	return dcs
+}
+
+// LoadOrNewForManaged returns the associated *DesiredStateCache stored in this
+// DesiredStateCacheStore for the given managed resource.
+// If there is no DesiredStateCache stored previously, a new DesiredStateCache is created and
+// stored for the specified managed resource. Subsequent calls with the same managed
+// resource will return the previously instantiated and stored DesiredStateCache
+// for that managed resource
+func (dcs *DesiredStateCacheStore) LoadOrNewForManaged(mg xpresource.Managed) StateCache {
+	dcs.mu.Lock()
+	defer dcs.mu.Unlock()
+	stateCache, ok := dcs.store[mg.GetUID()]
+	if !ok {
+		l := dcs.logger.WithValues("cached-for", mg.GetUID(), "cached-for", mg.GetName())
+		dcs.store[mg.GetUID()] = NewDesiredStateCache(WithLogger(l))
+		stateCache = dcs.store[mg.GetUID()]
+	}
+	return stateCache
+}
+
+// Remove will remove the stored DesiredStateCache of the given managed
+// resource from this DesiredStateCacheStore.
+func (dcs *DesiredStateCacheStore) Remove(mg xpresource.Managed) {
+	dcs.mu.Lock()
+	defer dcs.mu.Unlock()
+	delete(dcs.store, mg.GetUID())
+}

--- a/pkg/kube/client/ssa/state_cache.go
+++ b/pkg/kube/client/ssa/state_cache.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	objectv1alpha2 "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha2"
@@ -33,33 +32,9 @@ type StateCache interface {
 // manifest.
 // Hash key can be used to determine the validity of the cache entry
 type DesiredStateCache struct {
-	logger logging.Logger
-	// mu protects the whole cache entry
-	mu        *sync.RWMutex
+	mu        sync.RWMutex
 	extracted *unstructured.Unstructured
 	hash      string
-}
-
-// DesiredStateCacheOption lets you configure the DesiredStateCache parameters
-type DesiredStateCacheOption func(dsc *DesiredStateCache)
-
-// WithLogger sets the logger of DesiredStateCache.
-func WithLogger(l logging.Logger) DesiredStateCacheOption {
-	return func(w *DesiredStateCache) {
-		w.logger = l
-	}
-}
-
-// NewDesiredStateCache initializes a DesiredStateCache with given options
-func NewDesiredStateCache(opts ...DesiredStateCacheOption) *DesiredStateCache {
-	w := &DesiredStateCache{
-		logger: logging.NewNopLogger(),
-		mu:     &sync.RWMutex{},
-	}
-	for _, f := range opts {
-		f(w)
-	}
-	return w
 }
 
 // GetStateFor returns the stored desired state if exists and valid, for the given *v1alpha2.Object
@@ -89,32 +64,13 @@ func (dc *DesiredStateCache) SetStateFor(obj *objectv1alpha2.Object, state *unst
 type DesiredStateCacheStore struct {
 	mu    sync.RWMutex
 	store map[types.UID]*DesiredStateCache
-
-	logger logging.Logger
-}
-
-// DesiredStateCacheStoreOption lets you configure the DesiredStateCacheStore parameters
-type DesiredStateCacheStoreOption func(dcs *DesiredStateCacheStore)
-
-// WithCacheStoreLogger sets the logger of DesiredStateCacheStore.
-func WithCacheStoreLogger(l logging.Logger) DesiredStateCacheStoreOption {
-	return func(d *DesiredStateCacheStore) {
-		d.logger = l
-	}
 }
 
 // NewDesiredStateCacheStore returns a new DesiredStateCacheStore instance
-func NewDesiredStateCacheStore(opts ...DesiredStateCacheStoreOption) *DesiredStateCacheStore {
-	dcs := &DesiredStateCacheStore{
-		store:  map[types.UID]*DesiredStateCache{},
-		logger: logging.NewNopLogger(),
+func NewDesiredStateCacheStore() *DesiredStateCacheStore {
+	return &DesiredStateCacheStore{
+		store: map[types.UID]*DesiredStateCache{},
 	}
-
-	for _, f := range opts {
-		f(dcs)
-	}
-
-	return dcs
 }
 
 // LoadOrNewForManaged returns the associated *DesiredStateCache stored in this
@@ -136,8 +92,7 @@ func (dcs *DesiredStateCacheStore) LoadOrNewForManaged(mg xpresource.Managed) St
 	// need to recheck cache as might have been populated already
 	stateCache, ok = dcs.store[mg.GetUID()]
 	if !ok {
-		l := dcs.logger.WithValues("cached-for", mg.GetName(), "id", mg.GetUID())
-		dcs.store[mg.GetUID()] = NewDesiredStateCache(WithLogger(l))
+		dcs.store[mg.GetUID()] = &DesiredStateCache{}
 		stateCache = dcs.store[mg.GetUID()]
 	}
 	return stateCache

--- a/pkg/kube/client/ssa/state_cache.go
+++ b/pkg/kube/client/ssa/state_cache.go
@@ -63,13 +63,13 @@ func (dc *DesiredStateCache) SetStateFor(obj *objectv1alpha2.Object, state *unst
 // managed resource instance.
 type DesiredStateCacheManager struct {
 	mu    sync.RWMutex
-	store map[types.UID]*DesiredStateCache
+	store map[types.UID]StateCache
 }
 
 // NewDesiredStateCacheManager returns a new DesiredStateCacheManager instance
 func NewDesiredStateCacheManager() *DesiredStateCacheManager {
 	return &DesiredStateCacheManager{
-		store: map[types.UID]*DesiredStateCache{},
+		store: map[types.UID]StateCache{},
 	}
 }
 

--- a/pkg/kube/client/ssa/state_cache_test.go
+++ b/pkg/kube/client/ssa/state_cache_test.go
@@ -1,0 +1,378 @@
+package ssa
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha2"
+)
+
+func exampleExternalResourceRaw(resName, fieldValue string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"apiVersion": "api.example.org/v1",
+		"kind": "MyCoolKind",
+		"metadata": {
+			"name": %q
+		}
+		"spec": {
+			"coolField": %q
+		}
+	}`, resName, fieldValue))
+}
+
+func exampleManifestHash(resName, fieldValue string) string {
+	return fmt.Sprintf("%x", sha256.Sum256(exampleExternalResourceRaw(resName, fieldValue)))
+}
+
+func exampleExtractedResource(resName, fieldValue string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "api.example.org/v1",
+			"kind":       "FooKind",
+			"metadata": map[string]interface{}{
+				"name": resName,
+			},
+			"spec": map[string]interface{}{
+				"coolField": fieldValue,
+			},
+		},
+	}
+}
+
+type mockStateCache struct {
+	u    *unstructured.Unstructured
+	hash string
+}
+
+func (m *mockStateCache) SetStateFor(_ *v1alpha2.Object, _ *unstructured.Unstructured) {
+	// do nothing
+}
+
+func (m *mockStateCache) GetStateFor(obj *v1alpha2.Object) (*unstructured.Unstructured, bool) {
+	if m.hash == fmt.Sprintf("fake-manifest-hash-of-%s", obj.GetUID()) {
+		return m.u, true
+	}
+	return nil, false
+}
+
+func buildCacheManagerStore(existingObjectUIDs []types.UID) map[types.UID]StateCache {
+	store := make(map[types.UID]StateCache)
+	for _, uid := range existingObjectUIDs {
+
+		store[uid] = &mockStateCache{
+			u: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "FooKind",
+					"metadata": map[string]interface{}{
+						"name": fmt.Sprintf("manifest-of-%s", uid),
+					},
+				},
+			},
+			hash: fmt.Sprintf("fake-manifest-hash-of-%s", uid),
+		}
+	}
+	return store
+}
+
+func TestStateCacheManager(t *testing.T) {
+	tests := []struct {
+		name                string
+		existingObjectUIDs  []types.UID
+		wantCachedObjects   []*v1alpha2.Object
+		wantUncachedObjects []*v1alpha2.Object
+	}{
+		{
+			name: "LoadOrNew_Then_Remove",
+			existingObjectUIDs: []types.UID{
+				types.UID("foo-uid"),
+				types.UID("bar-uid"),
+			},
+			wantCachedObjects: []*v1alpha2.Object{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo-object",
+						UID:  types.UID("foo-uid"),
+					},
+					Spec: v1alpha2.ObjectSpec{
+						ForProvider: v1alpha2.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("manifest-of-foo-uid")},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar-object",
+						UID:  types.UID("bar-uid"),
+					},
+					Spec: v1alpha2.ObjectSpec{
+						ForProvider: v1alpha2.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("manifest-of-bar-uid")},
+						},
+					},
+				},
+			},
+			wantUncachedObjects: []*v1alpha2.Object{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "baz-object",
+						UID:  types.UID("baz-uid"),
+					},
+					Spec: v1alpha2.ObjectSpec{
+						ForProvider: v1alpha2.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("manifest-of-baz-uid")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			manager := NewDesiredStateCacheManager()
+			manager.store = buildCacheManagerStore(tt.existingObjectUIDs)
+			// assert fresh caches for uncached objects
+			for _, mg := range tt.wantUncachedObjects {
+				cache := manager.LoadOrNewForManaged(mg)
+				if cache == nil {
+					t.Fatalf("cache was nil for uid %v", mg)
+				}
+				if _, ok := cache.GetStateFor(mg); ok {
+					t.Fatalf("expected fresh desired state cache for object %v", mg)
+				}
+			}
+
+			// assert existing caches to be retrieved
+			for _, mg := range tt.wantCachedObjects {
+				cache := manager.LoadOrNewForManaged(mg)
+				if cache == nil {
+					t.Fatalf("expected state cache to be non-nil for object uid %v", mg)
+				}
+				dsc, ok := cache.GetStateFor(mg)
+				if !ok {
+					t.Fatalf("expected non-empty desired state cache for object %v", mg)
+				}
+
+				wantUID := fmt.Sprintf("manifest-of-%s", mg.GetUID())
+				if diff := cmp.Diff(wantUID, dsc.GetName()); diff != "" {
+					t.Fatalf("Cached desired state mismatch: -want cached with name, +got \n: %v", diff)
+				}
+
+			}
+
+			if diff := cmp.Diff(len(tt.wantCachedObjects)+len(tt.wantUncachedObjects), len(manager.store)); diff != "" {
+				t.Fatalf("managed cache count: -want, +got\n: %v", diff)
+			}
+
+			// remove and re-add, assert fresh caches
+			for _, pc := range tt.wantCachedObjects {
+				manager.Remove(pc)
+				cache := manager.LoadOrNewForManaged(pc)
+				if cache == nil {
+					t.Fatalf("cache was nil for PC %v", pc)
+				}
+				if _, ok := cache.GetStateFor(pc); ok {
+					t.Fatalf("expected fresh desired state cache for object %v after removal and re-load", pc)
+				}
+			}
+		})
+	}
+}
+
+func TestDesiredStateCache_GetStateFor(t *testing.T) {
+	tests := []struct {
+		name          string
+		argStateCache StateCache
+		argObject     *v1alpha2.Object
+		wantFound     bool
+		wantExtracted *unstructured.Unstructured
+	}{
+		{
+			name: "ValidEntry",
+			argObject: &v1alpha2.Object{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo-object",
+					UID:  types.UID("foo-uid"),
+				},
+				Spec: v1alpha2.ObjectSpec{
+					ForProvider: v1alpha2.ObjectParameters{
+						Manifest: runtime.RawExtension{Raw: exampleExternalResourceRaw("manifest-of-foo", "foo")},
+					},
+				},
+			},
+			argStateCache: &DesiredStateCache{
+				extracted: &unstructured.Unstructured{},
+				hash:      exampleManifestHash("manifest-of-foo", "foo"),
+			},
+			wantFound:     true,
+			wantExtracted: &unstructured.Unstructured{},
+		},
+		{
+			name: "StaleEntry",
+			argObject: &v1alpha2.Object{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar-object",
+					UID:  types.UID("bar-uid"),
+				},
+				Spec: v1alpha2.ObjectSpec{
+					ForProvider: v1alpha2.ObjectParameters{
+						Manifest: runtime.RawExtension{Raw: []byte("manifest-of-bar-uid")},
+					},
+				},
+			},
+			argStateCache: &DesiredStateCache{
+				extracted: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "BarKind",
+						"metadata": map[string]interface{}{
+							"name": "manifest-of-bar",
+						},
+					},
+				},
+				hash: "some-non-matching-hash",
+			},
+			wantFound:     false,
+			wantExtracted: nil,
+		},
+		{
+			name: "EmptyCache",
+			argObject: &v1alpha2.Object{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar-object",
+					UID:  types.UID("bar-uid"),
+				},
+				Spec: v1alpha2.ObjectSpec{
+					ForProvider: v1alpha2.ObjectParameters{
+						Manifest: runtime.RawExtension{Raw: []byte("manifest-of-bar-uid")},
+					},
+				},
+			},
+			argStateCache: &DesiredStateCache{},
+			wantFound:     false,
+			wantExtracted: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extracted, found := tt.argStateCache.GetStateFor(tt.argObject)
+			if diff := cmp.Diff(tt.wantFound, found); diff != "" {
+				t.Fatalf("GetStateFor(...): -want found, +got found: %s", diff)
+			}
+			if diff := cmp.Diff(tt.wantExtracted, extracted); diff != "" {
+				t.Fatalf("GetStateFor(...): -want extracted, +got extracted: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDesiredStateCache_SetStateFor(t *testing.T) {
+	tests := []struct {
+		name          string
+		argStateCache *DesiredStateCache
+		argObject     *v1alpha2.Object
+		argExtracted  *unstructured.Unstructured
+		wantHash      string
+		wantExtracted *unstructured.Unstructured
+	}{
+		{
+			name: "OntoEmptyCache",
+			argObject: &v1alpha2.Object{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar-object",
+					UID:  types.UID("bar-uid"),
+				},
+				Spec: v1alpha2.ObjectSpec{
+					ForProvider: v1alpha2.ObjectParameters{
+						Manifest: runtime.RawExtension{Raw: exampleExternalResourceRaw("manifest-of-bar", "barValue")},
+					},
+				},
+			},
+			argStateCache: &DesiredStateCache{},
+			argExtracted:  exampleExtractedResource("manifest-of-bar", "barValue"),
+			wantExtracted: exampleExtractedResource("manifest-of-bar", "barValue"),
+			wantHash:      exampleManifestHash("manifest-of-bar", "barValue"),
+		},
+		{
+			name: "OntoStaleEntry",
+			argObject: &v1alpha2.Object{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar-object",
+					UID:  types.UID("bar-uid"),
+				},
+				Spec: v1alpha2.ObjectSpec{
+					ForProvider: v1alpha2.ObjectParameters{
+						Manifest: runtime.RawExtension{Raw: exampleExternalResourceRaw("manifest-of-bar", "barValue")},
+					},
+				},
+			},
+			argStateCache: &DesiredStateCache{
+				extracted: exampleExtractedResource("manifest-of-stale", "some-stale-value"),
+				hash:      "some-non-matching-hash",
+			},
+			argExtracted:  exampleExtractedResource("manifest-of-bar", "barValue"),
+			wantHash:      exampleManifestHash("manifest-of-bar", "barValue"),
+			wantExtracted: exampleExtractedResource("manifest-of-bar", "barValue"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.argStateCache.SetStateFor(tt.argObject, tt.argExtracted)
+
+			if diff := cmp.Diff(tt.wantHash, tt.argStateCache.hash); diff != "" {
+				t.Fatalf("SetStateFor(...): -want hash, +got hash: %s", diff)
+			}
+			if diff := cmp.Diff(tt.argExtracted, tt.argStateCache.extracted); diff != "" {
+				t.Fatalf("SetStateFor(...): -want extracted, +got extracted: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDesiredStateCache_SetGet(t *testing.T) {
+	tests := []struct {
+		name   string
+		object *v1alpha2.Object
+		state  *unstructured.Unstructured
+	}{
+		{
+			name: "SetGet",
+			object: &v1alpha2.Object{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo-object",
+					UID:  types.UID("foo-uid"),
+				},
+				Spec: v1alpha2.ObjectSpec{
+					ForProvider: v1alpha2.ObjectParameters{
+						Manifest: runtime.RawExtension{Raw: exampleExternalResourceRaw("manifest-of-foo", "foo")},
+					},
+				},
+			},
+			state: exampleExtractedResource("manifest-of-foo", "foo"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsc := &DesiredStateCache{}
+			dsc.SetStateFor(tt.object, tt.state)
+			cachedState, found := dsc.GetStateFor(tt.object)
+			if !found {
+				t.Fatalf("SetThenGet(...): expected cached state but none found")
+			}
+			if diff := cmp.Diff(tt.state, cachedState); diff != "" {
+				t.Fatalf("SetGet: -want extracted, +got extracted: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

caches for the calculated desired state during observation per `Object`. This is to avoid an extra dry-run call introduced due to the upstream k8s bug regarding defaulting of `unstructuredExtractor` 

Fixes https://github.com/crossplane-contrib/provider-kubernetes/issues/269
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
